### PR TITLE
Fix usage of React component

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/bgryszko/react-native-circular-progress",
   "dependencies": {
-    "art": "^0.10.0"
+    "art": "^0.10.0",
+    "prop-types": "15.6.0"
   }
 }

--- a/src/AnimatedCircularProgress.js
+++ b/src/AnimatedCircularProgress.js
@@ -1,4 +1,6 @@
-import React, { PropTypes, Animated } from 'react-native';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Animated } from 'react-native';
 import CircularProgress from './CircularProgress';
 const AnimatedProgress = Animated.createAnimatedComponent(CircularProgress);
 

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { View, Platform } from 'react-native';
 import { Surface, Shape, Path, Group } from '../../react-native/Libraries/ART/ReactNativeART';
-import MetricsPath from 'art/metrics/path';
 
 export default class CircularProgress extends React.Component {
 

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -1,4 +1,6 @@
-import React, { View, PropTypes, Platform } from 'react-native';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View, Platform } from 'react-native';
 import { Surface, Shape, Path, Group } from '../../react-native/Libraries/ART/ReactNativeART';
 import MetricsPath from 'art/metrics/path';
 


### PR DESCRIPTION
Importing `React` and `PropTypes` from `react-native` is invalid. If `React.Component` is used based on that import an error will be thrown. Therefore adjusted the import to import from 'react'. Also the `PropTypes` package was moved to a separate package in newer versions, therefore I added the `prop-types` dependency.